### PR TITLE
Set defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,8 +110,8 @@ func GetConfig(v *viper.Viper, logger *syslog.Writer) (*Config, chan *Config, Ou
 func setDefaults(v *viper.Viper) {
 	v.SetDefault(LoggingDirectory, "log")
 	v.SetDefault(LoggingActiveFileName, "out.log")
-	v.SetDefault(RotationMaxLines, 100)
-	v.SetDefault(RotationMaxFileSizeBytes, 1000000)
+	v.SetDefault(RotationMaxLines, 100000)
+	v.SetDefault(RotationMaxFileSizeBytes, 5000000)
 	v.SetDefault(FlushingTimeIntervalSecs, 5)
 	v.SetDefault(PrependValue, "")
 	v.SetDefault(FileRenamePolicy, "timestamp")


### PR DESCRIPTION
The config file (https://github.com/agnivade/funnel/blob/master/config.toml) sets defaults of 100,000 log entries, and 5MB rotation, with a maximum of 100 files.

In this case you then have at most 100 files (at most 500MB disk space, at most 10,000,000 log entries)

Without a config file, the default is 100 lines per file and at most 100 files. I think 100 lines per file is unreasonably small, especially since it means you can only store a maximum of 10,000 log entries over the 30 day max age.

This could catch someone out.

I think making sure that the example config file should match the defaults if you haven't set one up.