### PR TITLE
Use lexical sorting filenames.

### DIFF
--- a/rollup.go
+++ b/rollup.go
@@ -16,12 +16,12 @@ import (
 
 // Renames a file with the current timestamp
 func renameFileTimestamp(cfg *Config) (string, error) {
-	t := time.Now()
+	newFileName := time.Now().UTC().Format("2006-01-02_15-04-05.00000") + ".log"
 	err := os.Rename(
 		path.Join(cfg.DirName, cfg.ActiveFileName),
-		path.Join(cfg.DirName, t.Format("15_04_05.00000-2006_01_02")+".log"),
+		path.Join(cfg.DirName, newFileName),
 	)
-	return t.Format("15_04_05.00000-2006_01_02") + ".log", err
+	return newFileName, err
 }
 
 // Renames files serially by increasing suffix by 1

--- a/rollup_test.go
+++ b/rollup_test.go
@@ -1,6 +1,7 @@
 package funnel
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -40,8 +41,11 @@ func TestRenameFileTimestamp(t *testing.T) {
 	if len(files) != 1 {
 		t.Errorf("Incorrect no. of files created. Expected 1, Got %d", len(files))
 	}
+
+	dateRegex := "[0-9]{4}-[0-9]{2}-[0-9]{2}"
+	timeRegex := "[0-9]{2}-[0-9]{2}-[0-9]{2}.[0-9]{5}"
+	regexStr := fmt.Sprintf("%s_%s%s", dateRegex, timeRegex, ".log")
 	for _, file := range files {
-		regexStr := "[0-9]{2}_[0-9]{2}_[0-9]{2}.[0-9]{5}-[0-9]{4}_[0-9]{2}_[0-9]{2}.log"
 		matched, err := regexp.MatchString(regexStr, file.Name())
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
A change to the filename to make it UTC and start with the date, then the time, e.g. "2017-01-18T15-54-18.54316.log".

As per RFC 3339:

```
5.1. Ordering

   If date and time components are ordered from least precise to most
   precise, then a useful property is achieved.  Assuming that the time
   zones of the dates and times are the same (e.g., all in UTC),
   expressed using the same string (e.g., all "Z" or all "+00:00"), and
   all times have the same number of fractional second digits, then the
   date and time strings may be sorted as strings (e.g., using the
   strcmp() function in C) and a time-ordered sequence will result.  The
   presence of optional punctuation would violate this characteristic.
```

The current implementation starts with time, so if you've got a few days worth of logs in there, when you use `ls` or similar, then the files aren't ordered as you might expect.